### PR TITLE
Fix the vulnerability CVE-2020-15250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/jramoyo/io/BufferedRandomAccessFile.java
+++ b/src/main/java/com/jramoyo/io/BufferedRandomAccessFile.java
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
  * Extends <code>RandomAccessFile</code> to support buffered reads.
  * </p>
  * 
- * @see http://www.javaworld.com/javaworld/javatips/jw-javatip26.html
+ * XXXXXsee http://www.javaworld.com/javaworld/javatips/jw-javatip26.html
  * @author jramoyo
  */
 public class BufferedRandomAccessFile extends RandomAccessFile {
@@ -49,7 +49,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 *            the file object
 	 * @param mode
 	 *            the access mode
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public BufferedRandomAccessFile(File file, String mode) throws IOException {
 		this(file, mode, DEFAULT_BUFFER_SIZE);
@@ -64,7 +64,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 *            the access mode
 	 * @param bufferSize
 	 *            the size of the read buffer
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public BufferedRandomAccessFile(File file, String mode, int bufferSize)
 			throws IOException {
@@ -81,7 +81,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 *            the path to the file
 	 * @param mode
 	 *            the access mode
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public BufferedRandomAccessFile(String filename, String mode)
 			throws IOException {
@@ -97,7 +97,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 *            the access mode
 	 * @param bufsize
 	 *            the size of the read buffer
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public BufferedRandomAccessFile(String filename, String mode, int bufsize)
 			throws IOException {
@@ -136,7 +136,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 * 
 	 * @return the next line of text from this file, or null if end of file is
 	 *         encountered before even one byte is read.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public final String getNextLine() throws IOException {
 		return getNextLine(Charset.defaultCharset());
@@ -162,7 +162,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 *            the character set to use when reading the line
 	 * @return the next line of text from this file, or null if end of file is
 	 *         encountered before even one byte is read.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public final String getNextLine(Charset charset) throws IOException {
 		String str = null;
@@ -225,7 +225,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 * 
 	 * @return the next byte of data, or -1 if the end of the file has been
 	 *         reached.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	@Override
 	public final int read() throws IOException {
@@ -258,7 +258,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 *            the start offset in array b at which the data is written.
 	 * @param len
 	 *            the maximum number of bytes read.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	@Override
 	public int read(byte b[], int off, int len) throws IOException {
@@ -296,7 +296,7 @@ public class BufferedRandomAccessFile extends RandomAccessFile {
 	 * @param pos
 	 *            the offset position, measured in bytes from the beginning of
 	 *            the file, at which to set the file pointer.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	@Override
 	public void seek(long pos) throws IOException {

--- a/src/main/java/com/jramoyo/io/IndexedFileReader.java
+++ b/src/main/java/com/jramoyo/io/IndexedFileReader.java
@@ -79,7 +79,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 * 
 	 * @param file
 	 *            the <code>File</code> to read from
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public IndexedFileReader(File file) throws IOException {
 		this(file, Charset.defaultCharset(), 1, DEFAULT_POOL);
@@ -96,7 +96,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 *            the <code>File</code> to read from
 	 * @param charset
 	 *            the character set to use
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public IndexedFileReader(File file, Charset charset) throws IOException {
 		this(file, charset, 1, DEFAULT_POOL);
@@ -117,7 +117,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 * @param splitCount
 	 *            the number of times the file will be divided during concurrent
 	 *            indexing
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public IndexedFileReader(File file, Charset charset, int splitCount)
 			throws IOException {
@@ -141,7 +141,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 *            indexing
 	 * @param pool
 	 *            the pool to use when concurrently indexing the file
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public IndexedFileReader(File file, Charset charset, int splitCount,
 			ForkJoinPool pool) throws IOException {
@@ -170,7 +170,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 * @param splitCount
 	 *            the number of times the file will be divided during concurrent
 	 *            indexing
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public IndexedFileReader(File file, int splitCount) throws IOException {
 		this(file, Charset.defaultCharset(), splitCount, DEFAULT_POOL);
@@ -194,7 +194,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 *            the regular expression to match
 	 * @return a sorted map of lines matching the regular expression, having the
 	 *         line number as key and the text as value.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public SortedMap<Integer, String> find(int from, int to, String regex)
 			throws IOException {
@@ -251,7 +251,7 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	 *            the number of lines
 	 * @return a map of the first n number of lines, having the line number as
 	 *         key and the text as value.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public SortedMap<Integer, String> head(int n) throws IOException {
 		assertNotClosed();
@@ -266,15 +266,13 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	/**
 	 * Reads lines given a range of line numbers
 	 * 
-	 * @param file
-	 *            the file to read
 	 * @param from
 	 *            the starting line
 	 * @param to
 	 *            the end line
 	 * @return a sorted map of lines read, having the line number as key and the
 	 *         text as value.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public SortedMap<Integer, String> readLines(int from, int to)
 			throws IOException {
@@ -317,13 +315,11 @@ public final class IndexedFileReader implements Closeable, AutoCloseable {
 	/**
 	 * Returns the last n number of lines
 	 * 
-	 * @param file
-	 *            the file to read
 	 * @param n
 	 *            the number of lines
 	 * @return a map of the last n number of lines, having the line number as
 	 *         key and the text as value.
-	 * @throws IOException
+	 * @throws IOException TODO: put description here
 	 */
 	public SortedMap<Integer, String> tail(int n) throws IOException {
 		assertNotClosed();


### PR DESCRIPTION
As you may see on project's page https://mvnrepository.com/artifact/com.jramoyo/indexed-file-reader/1.0 it's marked as non secure due to vulnerability CVE-2020-15250. This PR fixes this.